### PR TITLE
Solve the issue with the database name by the arduino firmware

### DIFF
--- a/Assets/ConnectToArduino/Arduino.cs
+++ b/Assets/ConnectToArduino/Arduino.cs
@@ -70,7 +70,6 @@ public class Arduino : MonoBehaviour {
     private Dictionary<string, string> NewestIncomingData;
     private int numberOfColumns = 1;
     public string separator = "\t";
-    private string outputLabel;
     private string email;
     private Dictionary<string, List<string>> logCollection;
     public List<string> headers;
@@ -118,7 +117,6 @@ public class Arduino : MonoBehaviour {
             if (serialInput.Contains ("LOG BEGIN")) {
                 // Parse Reported Column and Separator
                 ParseDataArguments(serialInput);
-                onLoggingStarted.Invoke(outputLabel);
 
                 // Initialize the log dictionary
                 logCollection = new Dictionary<string, List<string>>();
@@ -143,7 +141,6 @@ public class Arduino : MonoBehaviour {
                 // Otherwise error out and go to Standby Mode.
                 Debug.LogError("Received " + headers.Count + "columns, but Arduino reported " + numberOfColumns + "! Data Discarded..");
                 receiverState = ReceiverState.Standby;
-                onLoggingInterrupted.Invoke(outputLabel);
             }
         } else if (receiverState == ReceiverState.ReadingData) {
             // Check for "END" strings
@@ -168,8 +165,7 @@ public class Arduino : MonoBehaviour {
                 } else {
                     // Otherwise error out and go to Standby Mode.
                     Debug.LogError("Received " + bodyData.Length + "columns, but Arduino reported " + numberOfColumns + "! Data Discarded..");
-                    //receiverState = ReceiverState.Standby;
-                    //onLoggingInterrupted.Invoke(outputLabel);
+                    receiverState = ReceiverState.Standby;
                 }
             }
         }
@@ -231,8 +227,6 @@ public class Arduino : MonoBehaviour {
 					if (!result) {
 						Debug.LogError("Could not parse column length argument: " + val + " - use fx LOG BEGIN (col=5).");
 					}
-			} else if (param == "label") {
-					outputLabel = val;
 			} else {
 				Debug.LogWarning("Arduino reported an unknown parameter: " + param);
 			}


### PR DESCRIPTION
this pull request is created to solve the issue #19  . The database tablename was set by the label on the arduino firmware begin output , it was also set in the unity app with the output label event. so the solution is to delete this event. 

the selected database is now the one set on the credentials.