### PR TITLE
Fixing read-only issue, fixing bugs/adding features and adding LoggingExample

### DIFF
--- a/Assets/LoggingManager/ConnectToMySQL.cs
+++ b/Assets/LoggingManager/ConnectToMySQL.cs
@@ -261,6 +261,7 @@ public class ConnectToMySQL : MonoBehaviour
 		if (logDictionary.Keys.Count == 0)
 		{
 			Debug.LogError("the logs " + targetLabel + " contain no columns!");
+            logStore.RemoveSavingTarget(TargetType.MySql);
 			return;
 		}
 
@@ -273,6 +274,7 @@ public class ConnectToMySQL : MonoBehaviour
 		{
 			Debug.LogError("The targetLabel " + targetLabel + " does not match any of the loaded targets.");
 			Debug.LogError("Aborting AddToUploadQueue..");
+            logStore.RemoveSavingTarget(TargetType.MySql);
 		}
 	}
 

--- a/Assets/LoggingManager/LogStore.cs
+++ b/Assets/LoggingManager/LogStore.cs
@@ -174,18 +174,10 @@ public class LogStore
     {
         string timeStamp = GetTimeStamp();
         string frameCount = GetFrameCount();
-        if (LogType == LogType.LogEachRow)
-        {
-            AddToDictIfNotExists(CurrentLogRow, "Timestamp", timeStamp);
-            AddToDictIfNotExists(CurrentLogRow, "Framecount", frameCount);
-            AddToDictIfNotExists(CurrentLogRow, "SessionID", SessionId);
-            AddToDictIfNotExists(CurrentLogRow, "Email", email);
-        }
-        else if (LogType == LogType.OneRowOverwrite)
-        {
-            AddToDictIfNotExists(CurrentLogRow, "SessionID", SessionId);
-            AddToDictIfNotExists(CurrentLogRow, "Email", email);
-        }
+        AddToDictIfNotExists(CurrentLogRow, "Timestamp", timeStamp);
+        AddToDictIfNotExists(CurrentLogRow, "Framecount", frameCount);
+        AddToDictIfNotExists(CurrentLogRow, "SessionID", SessionId);
+        AddToDictIfNotExists(CurrentLogRow, "Email", email);
     }
 
     //Terminates the current row 

--- a/Assets/LoggingManager/LogStore.cs
+++ b/Assets/LoggingManager/LogStore.cs
@@ -20,7 +20,7 @@ public class LogStore
     private StringBuilder logString;
     public string Label { get; set; }
 
-    public bool IsReadOnly { get; set; }
+    private List<TargetType> targetsSaving;
     private bool isLogStringReady;
 
     public LogType LogType;
@@ -64,7 +64,7 @@ public class LogStore
         LogType logType)
     {
         InitiateTargetsSaved();
-        IsReadOnly = false;
+        targetsSaving = new List<TargetType>();
         this.Label = label;
         logs = new SortedDictionary<string, List<string>>();
         logString = new StringBuilder();
@@ -110,7 +110,7 @@ public class LogStore
     public void Add(string column, object data)
     {
         //if IsReadOnly is true, it is impossible to add data to the logs
-        if (IsReadOnly)
+        if (IsReadOnly())
         {
             Debug.LogError("Impossible to add data to log " + Label + " while saving it");
             return;
@@ -227,11 +227,27 @@ public class LogStore
         RowCount++;
     }
 
+    public void AddSavingTarget(TargetType targetType)
+    {
+        targetsSaving.Add(targetType);
+    }
+
+    public void RemoveSavingTarget(TargetType targetType)
+    {
+        targetsSaving.Remove(targetType);
+    }
+
+    //if targetsSaving is not empty, then the logStore is read-only
+    public bool IsReadOnly()
+    {
+        return targetsSaving.Count != 0;
+    }
+
     //Clears all the logs
     public void Clear()
     {
         //if IsReadOnly is true, it is impossible to clear the logs
-        if (IsReadOnly)
+        if (IsReadOnly())
         {
             Debug.LogError("Impossible to clear the log " + Label + " while saving it");
             return;

--- a/Assets/LoggingManager/LoggingExample.cs
+++ b/Assets/LoggingManager/LoggingExample.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+class LoggingExample
+{
+
+    private LoggingManager loggingManager;
+
+
+    private int highscore = 42;
+    private string player = "player1";
+    private float soundvol = 100f;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        // Find the logging Manager in the scene.
+        loggingManager = GameObject.Find("LoggingManager").GetComponent<LoggingManager>();
+
+
+        // Tell the logging manager to create the log called MyLabel
+        // For SQL connections, make sure that the label matches the label in your JSON file.
+        loggingManager.CreateLog("MyLabel");
+
+
+        // Tell the logging manager to store a piece of data into a column called "Highscore".
+        loggingManager.Log("MyLabel", "Highscore", highscore);
+
+        // You can also send a dictionary with multiple data entries at once.
+        Dictionary<string, object> otherData = new Dictionary<string, object>() {
+            {"SoundVolume", soundvol},
+            {"PlayerName", player}
+        };
+
+        loggingManager.Log("MyLabel", otherData);
+
+
+        // In each case, the logged line will be terminated, whether you have logged one or more data entries
+        // This means that if you want to log 2 entries in one row, you must use the appropriate function
+
+        // If enabled, you can also add data to the meta log
+        loggingManager.Log("Meta", "age",19);
+
+
+        // You can either set the SavePath in the editor or in the code
+        // If you want to to this in code, use this function
+        loggingManager.SetSavePath("/path/to/file.csv");
+
+        // Same thing for the email
+        loggingManager.SetEmail("example@create.aau.dk");
+
+
+        // Tell the logging manager to save the data (to disk and SQL by default).
+        // You can set the boolean to true if you want to clear the logs once saved
+        loggingManager.SaveLog("MyLabel",true);
+
+        // You can specify to save only to disk or to SQL
+        loggingManager.SaveLog("MyLabel",true,TargetType.CSV);
+        loggingManager.SaveLog("MyLabel", true, TargetType.MySql);
+
+
+        // Use this function to save all the logs at once
+        // You can also choose to save only one target here 
+        loggingManager.SaveAllLogs(true);
+        loggingManager.SaveAllLogs(true,TargetType.MySql);
+
+
+        // If you want to start new logs, you can ask loggingManager to generate
+        // a new random unique id. The data saved will now have a new SessionID value.
+        loggingManager.NewFilestamp();
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+
+
+}

--- a/Assets/LoggingManager/LoggingExample.cs.meta
+++ b/Assets/LoggingManager/LoggingExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca53a9c293c424e4ead3f0e1fa6f2a94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LoggingManager/LoggingManager.cs
+++ b/Assets/LoggingManager/LoggingManager.cs
@@ -268,6 +268,12 @@ public class LoggingManager : MonoBehaviour
     {
         if (logsList.ContainsKey(collectionLabel))
         {
+ 
+            foreach (var targetType in targetsEnabled)
+            {
+                logsList[collectionLabel].AddSavingTarget(targetType);
+            }
+
             //we generate the string and then we save the logs in the callback
             //by doing this, we are sure that the logs will be exported only once
             GenerateLogString(collectionLabel, () =>
@@ -377,18 +383,21 @@ public class LoggingManager : MonoBehaviour
         if (!logsList.ContainsKey(label))
         {
             Debug.LogError("Could not find collection " + label + ". Aborting.");
+            logsList[label].RemoveSavingTarget(TargetType.MySql);
             return;
         }
 
         if (logsList[label].RowCount == 0)
         {
             Debug.LogError("Collection " + label + " is empty. Aborting.");
+            logsList[label].RemoveSavingTarget(TargetType.MySql);
             return;
         }
 
         connectToMySQL.AddToUploadQueue(logsList[label], label);
         connectToMySQL.UploadNow(() =>
         {
+            logsList[label].RemoveSavingTarget(TargetType.MySql);
             logsList[label].TargetsSaved[TargetType.MySql] = true;
             SaveCallback(logsList[label], shouldClear);
         });

--- a/Assets/LoggingManager/WriteToCSV.cs
+++ b/Assets/LoggingManager/WriteToCSV.cs
@@ -52,10 +52,8 @@ public class WriteToCSV
 
         new Thread(() =>
         {
-            //disables the possibility to log data durring the saving process
-            logStore.IsReadOnly = true;
             Write();
-            logStore.IsReadOnly = false;
+            logStore.RemoveSavingTarget(TargetType.CSV);
             callback();
         }).Start();
     }


### PR DESCRIPTION
- Previously, when the `Clear()` function was called after the `Save()` one, the logs were cleared before being saved. This problem should be fixed.
- The Meta logs now contains all common columns (TimeStamp, Framecount, SessionID and Email).
- Adding the LoggingExample class.

The documentation of the loggingManager can be downloaded [here](https://github.com/med-material/ArduinoLogger/files/8041603/Readme.md)

See below for an overview of this documentation:

# Logging Manager


## Table of contents

- [Logging Manager](#logging-manager)
  - [Table of Contents](#table-of-contents)
  - [What is it](#what-is-it)
  - [How to use](#how-to-use)
    - [Import into project](#import-into-project)
      - [Import the Logging Manager](#import-the-logging-manager)
      - [Create a LoggingManager game object](#create-a-loggingmanager-game-object)
    - [Use in your project](#use-in-your-project)
      - [Recover the LoggingManager](#recover-the-loggingmanager)
      - [Start logging](#start-logging)
      - [Save the logs](#save-the-logs)
  - [Behavior](#behavior)
    - [Header definition](#header-definition)
  - [Parameters](#parameters)
      - [Enable CSV save](#enable-csv-save)
      - [Enable MySQL save](#enable-mysql-save)
      - [Create meta collection](#create-meta-collection)
      - [Log string over time](#log-string-over-time)
      - [Specify target directory](#specify-target-directory)

## What is it

The logging manager is a set of C# functions that can be used to log easily data into csv files and into a MySQL database.
It can be considered as an API that you can include in your Unity projects.


## How to use

### Import into project

#### Import the Logging Manager

First of all, you'll need to get the last release of the Logging Manager.
This version can be download [here](#). //TODO put link

Then, in your Unity project, go to `Assets - Import Package - Custom Package` and select the Logging Manager you just downloaded.

#### Create a LoggingManager game object

Create an Empty GameObject that you can call `LoggingManager`.
Add the LoggingManager script to the game object by going to `Add Component` and writing `LoggingManager`.

### Use in your project

#### Recover the LoggingManager

To use the LoggingManager in your code, you'll need to recover it.
You can do this like this :
```c#
LoggingManager = GameObject.Find("LoggingManager").GetComponent<LoggingManager>();
```

#### Start logging

Now that you have set up the LoggingManager, you are able to log data.
First, you need to create the Log connection using a Label:
```c#
LoggingManager.CreateLog("myLabel");
```
Then, you can start logging your data using 2 functions.
If you want to log only one column, use:
```c#
LoggingManager.Log("myLabel","myColumn",myValue);
```
If you want to log more than one column, use:
```c#
Dictionary<string, object> logs = new Dictionary<string, object>();
logs.Add("column1",value1);
logs.Add("column2",value2);
LoggingManager.Log("myLabel",logs);
```

In each case, right after you call the `Log` function, the log row will be ended and common colums like TimeStamp, Framecount, SessionID and Email will be added to the logs.

> **__NOTE:__** The SessionID is a unique randomly generated string. All logs created in the session will have the same SessionID.
> To generate a new one, you can call the LoggingManager.NewFileStamp() function.

#### Save the logs

When you are done logging, you can save your logs.
The way the logs will be saved depends on how you configured the LoggingManager in Unity (see the [Parameters](#Parameters) section).  

The saves functions take as parameters the label of the logs you want to save and a "shouldClear" boolean.
If set to true, the logs will be cleared after you save them.

To save one specific collection, you can use:
```c#
LoggingManager.SaveLog("collectionLabel", true);
```
You can also decide to only save to CSV or MySQL. To do that, simply specify the target when calling the save function:
```c#
LoggingManager.SaveLog("collectionLabel", true, TargetType.CSV);
LoggingManager.SaveLog("collectionLabel", true, TargetType.MySql);
```

You can also save all your logs by calling:
```c#
LoggingManager.SaveAllLogs(true);
```
Of course you can specify the target you want to save here too:
```c#
LoggingManager.SaveAllLogs(true, TargetType.CSV);
```

## Behavior

### Header definition
The header of a log is defined by the names of its columns.
In the LoggingManager, the headers are defined when you log your first row using the ```Log()``` function.

Let's take a loot at this example:
```c#
Dictionary<string, object> logs = new Dictionary<string, object>();
logs.Add("column1",value1);
logs.Add("column2",value2);
logs.Add("column3",value3);
LoggingManager.Log("myLabel",logs);
```
Here, the headers are column1, column2 and column3.
If you add a new header later in your code, the LoggingManager will add the new column and set all its previous values to NULL.
![headers](https://user-images.githubusercontent.com/49280157/153028516-7cbcc2a3-9688-40e5-b8b5-43576e10c5c3.png)
> **__NOTE:__**  It is a good practice to define all headers when logging the first row. Adding new headers later in the code, although supported, may result in loss of performance.
> Also, doing this will disable the [log string over time](#log-string-over-time) feature if it is enabled.

## Parameters

On the LoggingManager game object, you can configure some parameters.
Those parameters will change the behavior of the logging process and you can edit them by ticking the boxes or editing the text fields.

#### Enable CSV save

Tick the case if you want to save the logs into csv files.

#### Enable MySQL save

Tick the case if you want to send the logs to the database.

#### Create meta collection
If set to true, the LoggingManager will create a meta log automatically.
A meta log is a log that contains all information that need to be logged only once.
It can be for instance the age of the player or a comment about the session.

Each meta log will also have a SessionID column created automatically. This SessionID will be
the same as the one created in your regular logs.

If you want to log data in the Meta logs, simply do this using the Log function:
```c#
Dictionary<string, object> logs = new Dictionary<string, object>();
logs.Add("age",22);
logs.Add("comment","this is a comment");
LoggingManager.Log("Meta",logs);
```

#### Log string over time

When you log your data, the data have to be exported as a string to be saved into a CSV file or sent to a MySQL database. This will be our "datastring" and it will be in the following format:

`TimeStamp,positionX;positionY;positionZ\n2022-01-19 11:30:34.8123;100,50,100\n2022-01-19 11:30:35.8426;110,50,110`...

This datastring would produce a CSV file like this:

| TimeStamp | positionX | positionY | positionZ|
|--|--|--|--|
| 2022-01-19 11:30:34.8123 | 100 | 50 | 100 |
| 2022-01-19 11:30:35.8426 | 110| 50 | 110 |

To log this data, we have two possibilities.

##### Export the log string at the end of the logging process
In this case, the log string will be exported at the end of the logging process. That means that the program will have to iterate over all the saved logs and export them.

The advantage of this method is that it does not consume any CPU power during your session.
The disadvantage is that this process can take a long time depending of the quantity of data you want to save.

##### Create the log string over time during of the logging process
In this case, the log string will be exported over time during the logging process. This will result in a significantly faster saving time but this may have an impact on the performance of the session.

> **__NOTE:__**  If you want to use the log string over time feature, you will not be able to add new headers while logging (see [header definition](#header-definition)). If you do so anyway, the feature will be disabled and the string will be exported normally at the end of the process.


#### Specify target directory

By default, logs will be saved in "My documents". You can specify the path and the prefix of the file by editing those values.
The generated logs file will be called `yyyy_MM_dd_HH_mm_ss_ffff_label.csv`.

 